### PR TITLE
Fix long/int/bytes/basestring for python 2 and 3

### DIFF
--- a/boofuzz/helpers.py
+++ b/boofuzz/helpers.py
@@ -13,7 +13,7 @@ import struct
 import time
 import zlib
 
-from builtins import chr
+from builtins import int
 from past.builtins import map
 from past.builtins import range
 
@@ -209,7 +209,7 @@ def uuid_str_to_bin(uuid):
 
     matches = re.match(uuid_re, uuid)
 
-    (uuid1, uuid2, uuid3, uuid4, uuid5, uuid6) = map(lambda x: long(x, 16), matches.groups())
+    (uuid1, uuid2, uuid3, uuid4, uuid5, uuid6) = map(lambda x: int(x, 16), matches.groups())
 
     uuid = struct.pack('<LHH', uuid1, uuid2, uuid3)
     uuid += struct.pack('>HHL', uuid4, uuid5, uuid6)

--- a/boofuzz/utils/process_monitor_pedrpc_server.py
+++ b/boofuzz/utils/process_monitor_pedrpc_server.py
@@ -5,6 +5,7 @@ import shlex
 import time
 
 from past.builtins import map
+from builtins import str
 
 from boofuzz import pedrpc
 from boofuzz import utils
@@ -24,7 +25,7 @@ def _split_command_if_str(command):
     Returns:
         (:obj:`list` of :obj:`list`: of :obj:`str`): List of lists of command arguments.
     """
-    if isinstance(command, basestring):
+    if isinstance(command, str):
         return shlex.split(command)
     else:
         return command

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ setup(
             'Operating System :: OS Independent',
             'Programming Language :: Python',
             'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3.6',
             'Topic :: Security',
             'Topic :: Software Development :: Testing :: Traffic Generation',
         ]

--- a/unit_tests/primitives.py
+++ b/unit_tests/primitives.py
@@ -3,6 +3,7 @@ from boofuzz import *
 from past.builtins import xrange
 from io import open
 
+
 def run():
     signed_tests()
     string_tests()
@@ -90,7 +91,7 @@ def s_mirror_tests():
     for _ in xrange(len(TEST_GROUP_VALUES)):
         s_mutate()
         group_start_value = req.names['group_start'].render()
-        assert (req.names['size'].render() == str(len('<{0}>hello</{0}>'.format(group_start_value))))
+        assert (int(req.names['size'].render()) == len('<{0}>hello</{0}>'.format(group_start_value.decode("utf-8"))))
         assert (req.names['group_end'].render() == group_start_value)
         assert (req.names['size_mirror'].render() == req.names['size'].render())
 

--- a/utils/crashbin_explorer.py
+++ b/utils/crashbin_explorer.py
@@ -1,9 +1,9 @@
 #!c:\\python\\python.exe
 import getopt
-import six
 import sys
 
 from future.utils import iteritems
+from builtins import int
 
 import pgraph
 from boofuzz import utils
@@ -76,11 +76,7 @@ for _, crashes in iteritems(crashbin.bins):
             print("\t")
             last = crash_node.id
             for entry in crash.stack_unwind:
-                # python 3 doesn't have 'long' as its own type
-                if six.PY2:
-                    address = long(entry.split(":")[1], 16)
-                else:
-                    address = int(entry.split(":")[1], 16)
+                address = int(entry.split(":")[1], 16)
                 n = graph.find_node("id", address)
 
                 if not n:


### PR DESCRIPTION
This should at least run the actual unit-tests now. Most changes are made as suggested [here](https://python-future.org/compatible_idioms.html#long-integers) but I haven't tested if the actual result reflects the expected outcome.
The changes to the primitives.py are tested and `s_mirror_tests()` behaves exactly like it does in py27.

There are still many tests failing but we can at least see which ones now.
I hope this helps a little.
