### PR TITLE
 Fixed remaining unit-tests for python 2 and 3 

### DIFF
--- a/boofuzz/blocks/block.py
+++ b/boofuzz/blocks/block.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import
 
-from builtins import object
-
 import six
 
 from ..ifuzzable import IFuzzable
@@ -62,7 +60,7 @@ class Block(IFuzzable):
         original_value = six.binary_type(b"")
 
         for item in self.stack:
-            original_value += item.original_value
+            original_value += helpers.str_to_bytes(item.original_value)
 
         return original_value
 

--- a/boofuzz/blocks/request.py
+++ b/boofuzz/blocks/request.py
@@ -1,5 +1,4 @@
 import collections
-from builtins import object
 
 import six
 
@@ -64,7 +63,7 @@ class Request(IFuzzable):
         self._rendered = six.binary_type(b"")
 
         for item in self.stack:
-            self._rendered += item.original_value
+            self._rendered += helpers.str_to_bytes(item.original_value)
 
         return self._rendered
 

--- a/boofuzz/fuzz_logger_csv.py
+++ b/boofuzz/fuzz_logger_csv.py
@@ -53,10 +53,10 @@ class FuzzLoggerCsv(ifuzz_logger_backend.IFuzzLoggerBackend):
         self._print_log_msg(["error", "", "", description])
 
     def log_recv(self, data):
-        self._print_log_msg(["recv", len(data), self._format_raw_bytes(data), data])
+        self._print_log_msg(["recv", len(data), self._format_raw_bytes(data), data.decode()])
 
     def log_send(self, data):
-        self._print_log_msg(["send", len(data), self._format_raw_bytes(data), data])
+        self._print_log_msg(["send", len(data), self._format_raw_bytes(data), data.decode()])
 
     def log_info(self, description):
         self._print_log_msg(["info", "", "", description])

--- a/boofuzz/helpers.py
+++ b/boofuzz/helpers.py
@@ -234,10 +234,10 @@ def _collate_bytes(msb, lsb):
     Helper function for our helper functions.
     Collates msb and lsb into one 16-bit value.
 
-    :type msb: str
+    :type msb: byte
     :param msb: Single byte (most significant).
 
-    :type lsb: str
+    :type lsb: byte
     :param lsb: Single byte (least significant).
 
     :return: msb and lsb all together in one 16 bit value.
@@ -303,7 +303,7 @@ def udp_checksum(msg, src_addr, dst_addr):
 
 
     :param msg: Message to compute checksum over.
-    :type msg: str
+    :type msg: bytes
 
     :type src_addr: bytes
     :param src_addr: Source IP address -- 4 bytes.
@@ -421,6 +421,7 @@ def mkdir_safe(directory_name):
     except OSError as e:
         if e.errno != errno.EEXIST:
             raise
+
 
 def str_to_bytes(value):
     result = value

--- a/boofuzz/primitives/group.py
+++ b/boofuzz/primitives/group.py
@@ -29,7 +29,7 @@ class Group(BasePrimitive):
         self._value = self._original_value = default_value
 
         for val in self.values:
-            assert isinstance(val, six.binary_type), "Value list may only contain binary data"
+            assert isinstance(val, (six.binary_type, six.string_types)), "Value list may only contain string/byte types"
 
     @property
     def name(self):

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -919,8 +919,8 @@ class Session(pgraph.Graph):
             session (Session): Session object calling post_send.
                 Useful properties include last_send and last_recv.
 
-            args: Implementations should include \*args and \**kwargs for forward-compatibility.
-            kwargs: Implementations should include \*args and \**kwargs for forward-compatibility.
+            args: Implementations should include \\*args and \\**kwargs for forward-compatibility.
+            kwargs: Implementations should include \\*args and \\**kwargs for forward-compatibility.
         """
         # default to doing nothing.
         self._fuzz_data_logger.log_info("No post_send callback registered.")

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         packages=find_packages(exclude=['unit_tests', 'requests', 'examples', 'utils', 'web', 'new_examples']),
         package_data={'boofuzz': ['web/templates/*', 'web/static/css/*', 'web/static/js/*']},
         install_requires=[
-            'future', 'pyserial', 'pydot', 'tornado~=4.0', 'six',
+            'future', 'pyserial', 'pydot', 'tornado~=5.0', 'six',
             'Flask~=1.0', 'impacket', 'colorama', 'attrs', 'click', 'psutil', 'ldap3==2.5.1'],
         extras_require={
             # This list is duplicated in tox.ini. Make sure to change both!

--- a/unit_tests/test_fuzz_logger.py
+++ b/unit_tests/test_fuzz_logger.py
@@ -15,7 +15,7 @@ class TestFuzzLogger(unittest.TestCase):
         self.some_text = "Some test text"
         self.some_other_text = "More test text"
         self.some_int = 1
-        self.some_data = bytes('1234567890\0')
+        self.some_data = bytes(b"1234567890\0")
 
     def test_open_test_step(self):
         """

--- a/unit_tests/test_fuzz_logger_csv.py
+++ b/unit_tests/test_fuzz_logger_csv.py
@@ -156,7 +156,7 @@ class TestFuzzLoggerCsv(unittest.TestCase):
         six.assertRegex(self, self.virtual_file.readline(),
                         LOGGER_PREAMBLE + re.escape(
                             "recv," + str(len(self.some_recv_data)) + "," + fuzz_logger_csv.DEFAULT_HEX_TO_STR(
-                                self.some_recv_data) + "," + self.some_recv_data + "\r\n"))
+                                self.some_recv_data) + "," + self.some_recv_data.decode() + "\r\n"))
 
     def test_log_send(self):
         """
@@ -180,7 +180,7 @@ class TestFuzzLoggerCsv(unittest.TestCase):
         six.assertRegex(self, self.virtual_file.readline(),
                         LOGGER_PREAMBLE + re.escape(
                             "send," + str(len(self.some_send_data)) + "," + fuzz_logger_csv.DEFAULT_HEX_TO_STR(
-                                self.some_send_data) + "," + self.some_send_data + "\r\n"))
+                                self.some_send_data) + "," + self.some_send_data.decode() + "\r\n"))
 
     def test_log_info(self):
         """
@@ -471,11 +471,11 @@ class TestFuzzLoggerCsv(unittest.TestCase):
         six.assertRegex(self, self.virtual_file.readline(),
                         LOGGER_PREAMBLE + re.escape(
                             "recv," + str(len(self.some_recv_data)) + "," + fuzz_logger_csv.DEFAULT_HEX_TO_STR(
-                                self.some_recv_data) + "," + self.some_recv_data + "\r\n"))
+                                self.some_recv_data) + "," + self.some_recv_data.decode() + "\r\n"))
         six.assertRegex(self, self.virtual_file.readline(),
                         LOGGER_PREAMBLE + re.escape(
                             "send," + str(len(self.some_send_data)) + "," + fuzz_logger_csv.DEFAULT_HEX_TO_STR(
-                                self.some_send_data) + "," + self.some_send_data + "\r\n"))
+                                self.some_send_data) + "," + self.some_send_data.decode() + "\r\n"))
         six.assertRegex(self, self.virtual_file.readline(),
                         LOGGER_PREAMBLE + re.escape("info,,," + self.some_log_info_msg + "\r\n"))
         six.assertRegex(self, self.virtual_file.readline(),
@@ -519,7 +519,7 @@ class TestFuzzLoggerCsv(unittest.TestCase):
         six.assertRegex(self, self.virtual_file.readline(),
                         LOGGER_PREAMBLE + re.escape(
                             "recv," + str(len(self.some_recv_data)) + "," + hex_to_str(
-                                self.some_recv_data) + "," + str(self.some_recv_data) + "\r\n"))
+                                self.some_recv_data) + "," + self.some_recv_data.decode() + "\r\n"))
 
 
 if __name__ == '__main__':

--- a/unit_tests/test_fuzz_logger_text.py
+++ b/unit_tests/test_fuzz_logger_text.py
@@ -457,7 +457,7 @@ class TestFuzzLoggerText(unittest.TestCase):
         self.virtual_file.seek(0)
         self.assertTrue(self.some_test_case_id in self.virtual_file.readline())
         self.assertTrue(self.some_test_step_msg in self.virtual_file.readline())
-        self.assertTrue(str(len(self.some_recv_data)) in self.virtual_file.readline())
+        self.assertTrue(str(self.some_recv_data) in self.virtual_file.readline())
         self.assertTrue(str(len(self.some_send_data)) in self.virtual_file.readline())
         self.assertTrue(self.some_log_info_msg in self.virtual_file.readline())
         self.assertTrue(self.some_log_check_msg in self.virtual_file.readline())

--- a/unit_tests/test_socket_connection.py
+++ b/unit_tests/test_socket_connection.py
@@ -56,7 +56,7 @@ def udp_packet(payload, src_port, dst_port):
     Create a UDP packet.
 
     :param payload: Payload / next layer protocol.
-    :type payload: str
+    :type payload: bytes
 
     :param src_port: 16-bit source port number.
     :type src_port: int
@@ -65,7 +65,7 @@ def udp_packet(payload, src_port, dst_port):
     :type dst_port: int
 
     :return: UDP packet.
-    :rtype: str
+    :rtype: bytes
     """
     udp_header = struct.pack(">H", src_port)  # Src port
     udp_header += struct.pack(">H", dst_port)  # Dst port
@@ -89,20 +89,20 @@ def ip_packet(payload, src_ip, dst_ip, protocol=six.int2byte(ip_constants.IPV4_P
     """
     Create an IPv4 packet.
 
-    :type payload: str
+    :type payload: bytes
     :param payload: Contents of next layer up.
 
-    :type src_ip: str
+    :type src_ip: bytes
     :param src_ip: 4-byte source IP address.
 
-    :type dst_ip: str
+    :type dst_ip: bytes
     :param dst_ip: 4-byte destination IP address.
 
-    :type protocol: str
+    :type protocol: bytes
     :param protocol: Single-byte string identifying next layer's protocol. Default "\x11" UDP.
 
     :return: IPv4 packet.
-    :rtype: str
+    :rtype: bytes
     """
     ip_header = b"\x45"  # Version | Header Length
     ip_header += b"\x00"  # "Differentiated Services Field"
@@ -126,19 +126,19 @@ def ethernet_frame(payload, src_mac, dst_mac, ether_type=ETHER_TYPE_IPV4):
     Create an Ethernet frame.
 
     :param payload: Network layer content.
-    :type payload: str
+    :type payload: bytes
 
     :param src_mac: 6-byte source MAC address.
-    :type src_mac: str
+    :type src_mac: bytes
 
     :param dst_mac: 6-byte destination MAC address.
-    :type dst_mac: str
+    :type dst_mac: bytes
 
     :param ether_type: EtherType indicating protocol of next layer; default "\x08\x00" IPv4.
-    :type ether_type: str
+    :type ether_type: bytes
 
     :return: Ethernet frame
-    :rtype: str
+    :rtype: bytes
     """
     eth_header = dst_mac
     eth_header += src_mac
@@ -380,13 +380,14 @@ class TestSocketConnection(unittest.TestCase):
          and: Sent and received data is as expected.
         """
         try:
-            broadcast_addr = get_local_non_loopback_ipv4_addresses_info().next()['broadcast']
+            # broadcast_addr = get_local_non_loopback_ipv4_addresses_info().next()['broadcast']
+            broadcast_addr = six.next(get_local_non_loopback_ipv4_addresses_info())['broadcast']
         except StopIteration:
             assert False, TEST_ERR_NO_NON_LOOPBACK_IPV4
 
-        data_to_send = bytes('"Never drink because you need it, for this is rational drinking, and the way to death and'
-                             ' hell. But drink because you do not need it, for this is irrational drinking, and the'
-                             ' ancient health of the world."')
+        data_to_send = helpers.str_to_bytes('"Never drink because you need it, for this is rational drinking, and the '
+                                            'way to death and hell. But drink because you do not need it, for this is '
+                                            'irrational drinking, and the ancient health of the world."')
 
         # Given
         server = MiniTestServer(proto='udp', host='')

--- a/unit_tests/test_socket_connection.py
+++ b/unit_tests/test_socket_connection.py
@@ -380,7 +380,6 @@ class TestSocketConnection(unittest.TestCase):
          and: Sent and received data is as expected.
         """
         try:
-            # broadcast_addr = get_local_non_loopback_ipv4_addresses_info().next()['broadcast']
             broadcast_addr = six.next(get_local_non_loopback_ipv4_addresses_info())['broadcast']
         except StopIteration:
             assert False, TEST_ERR_NO_NON_LOOPBACK_IPV4


### PR DESCRIPTION
All unit-tests are finally passing 👌
We still need to test for runtime errors, also there are some tiny cosmetic bugs in the formatting of byte-strings in py3 where it shows them like `b'sometext'` instead of `'sometext'`.
I also pushed 'tornado' to version 5 as it is the last one that supports py2 and it works fine as far as I can tell.