### PR TITLE
Revert back to tornado v4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         packages=find_packages(exclude=['unit_tests', 'requests', 'examples', 'utils', 'web', 'new_examples']),
         package_data={'boofuzz': ['web/templates/*', 'web/static/css/*', 'web/static/js/*']},
         install_requires=[
-            'future', 'pyserial', 'pydot', 'tornado~=5.0', 'six',
+            'future', 'pyserial', 'pydot', 'tornado~=4.0', 'six',
             'Flask~=1.0', 'impacket', 'colorama', 'attrs', 'click', 'psutil', 'ldap3==2.5.1'],
         extras_require={
             # This list is duplicated in tox.ini. Make sure to change both!


### PR DESCRIPTION
Apparently my local py2.7 version differs from the one tavis is using during the checks.
The minimum version for tornado 5 is python 2.7.9, no idea what is actually running on travis maybe it's got another cause.
However, let's just revert back to v4 ... it's old but still seems to work.