### PR TITLE
Attempt to fix outdated py2 version on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-
+dist: xenial
 sudo: required
 
 before_install: sudo sed -i -e 's/^Defaults\tsecure_path.*$//' /etc/sudoers


### PR DESCRIPTION
So apparently travis runs on Ubuntu 14.04 by default. https://docs.travis-ci.com/user/reference/overview/
The latest py2 version for this distro is 2.7.6. https://askubuntu.com/questions/759687/how-can-i-install-a-newer-python-on-trusty
Setting the travis dist to 16.04 should fix this, but means that boofuzz won't run on 14.04 anymore.